### PR TITLE
Correction to package registration with service providers + aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Register the service provider within the ```providers``` array found in ```confi
 'providers' => [
 	// ...
 	
-	'Artdarek\OAuth\OAuthServiceProvider',
+	Artdarek\OAuth\OAuthServiceProvider::class,
 ]
 ```
 
@@ -93,7 +93,7 @@ Add an alias within the ```aliases``` array found in ```config/app.php```:
 'aliases' => [
 	// ...
 	
-	'OAuth' => 'Artdarek\OAuth\Facade\OAuth',
+	'OAuth'     => Artdarek\OAuth\Facade\OAuth::class,
 ]
 ```
 


### PR DESCRIPTION
The instruction on how to register the package with app's service providers and how to register alias is as of Laravel 4. Corrections made to support L5.
