### PR TITLE
modify readme to fix session class error

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Create configuration file manually in config directory ``config/oauth-5-laravel.
 
 ```php
 <?php
+
+use OAuth\Common\Storage\Session;
+
 return [ 
 	
 	/*
@@ -131,7 +134,7 @@ return [
 	/**
 	 * Storage
 	 */
-	'storage' => 'Session', 
+	'storage' => new Session(), 
 
 	/**
 	 * Consumers


### PR DESCRIPTION
Config files created before the update will throw an error.

Type error: Argument 3 passed to OAuth\ServiceFactory::createService() must be an instance of OAuth\Common\Storage\TokenStorageInterface, instance of Illuminate\Support\Facades\Session given, called in ~/vendor/oriceon/oauth-5-laravel/src/Artdarek/OAuth/OAuth.php on line 149
