### PR TITLE
Update to work with Laravel 5.4

### DIFF
--- a/src/Artdarek/OAuth/OAuthServiceProvider.php
+++ b/src/Artdarek/OAuth/OAuthServiceProvider.php
@@ -37,8 +37,7 @@ class OAuthServiceProvider extends ServiceProvider {
     public function register()
     {
         // Register 'oauth'
-        $this->app['oauth'] = $this->app->share(function ($app)
-        {
+        $this->app->singleton(OAuth::class, function ($app){
             // create oAuth instance
             $oauth = new OAuth();
 


### PR DESCRIPTION
The Share() function doesn't work anymore in Laravel 5.4, changed the register() function to make the php artisan vendor:publish work.

It change 
`$this->app['oauth'] = $this->app->share(function ($app)`

to 
`$this->app->singleton(OAuth::class, function ($app)`