### PR TITLE
Fix undefined method OAuth::consumer() in laravel 5.4

### DIFF
--- a/src/Artdarek/OAuth/Facade/OAuth.php
+++ b/src/Artdarek/OAuth/Facade/OAuth.php
@@ -15,5 +15,5 @@ class OAuth extends Facade {
      *
      * @return string
      */
-    protected static function getFacadeAccessor() { return 'oauth'; }
+    protected static function getFacadeAccessor() { return 'Artdarek\OAuth\OAuth'; }
 }


### PR DESCRIPTION
Call to undefined method Artdarek\OAuth\Facade\OAuth::consumer()