### PR TITLE
Update Lusitanian/PHPoAuthLib to latest version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "lusitanian/oauth": "~0.3"
+        "lusitanian/oauth": "^0.3"
     },
     "require-dev": {
         "illuminate/support": "~5"


### PR DESCRIPTION
Update Lusitanian/PHPoAuthLib to latest version 
and it fix Facebook oauth error: 
with message 'Undefined index: access_token' in lusitanian/oauth/src/OAuth/OAuth2/Service/Facebook.php:171