### PR TITLE
Update Lusitanian/PHPoAuthLib to latest version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "lusitanian/oauth": "^0.3"
+        "lusitanian/oauth": "0.*"
     },
     "require-dev": {
         "illuminate/support": "~5"


### PR DESCRIPTION
Real update Lusitanian/PHPoAuthLib to latest version, in previous commit little miss with how "^" works for pre-1.0 versions. Sorry about that.